### PR TITLE
feat: define cdk_assembly target

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 docs/*.md
 devbox.json
+e2e/workspace/package.json
+e2e/workspace/pnpm-lock.yaml

--- a/cdk/BUILD.bazel
+++ b/cdk/BUILD.bazel
@@ -27,6 +27,9 @@ bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//cdk/private:cdk_assembly",
+    ]
 )
 
 bzl_library(

--- a/cdk/defs.bzl
+++ b/cdk/defs.bzl
@@ -1,5 +1,5 @@
-"Public API re-exports"
+"""Rules for generating CDK assemblies and deploying them"""
 
-def example():
-    """This is an example"""
-    pass
+load("//cdk/private:assembly.bzl", _cdk_assembly = "cdk_assembly")
+
+cdk_assembly = _cdk_assembly

--- a/cdk/private/BUILD.bazel
+++ b/cdk/private/BUILD.bazel
@@ -11,3 +11,9 @@ bzl_library(
     srcs = ["versions.bzl"],
     visibility = ["//cdk:__subpackages__"],
 )
+
+bzl_library(
+    name = "cdk_assembly",
+    srcs = ["assembly.bzl"],
+    visibility = ["//cdk:__subpackages__"],
+)

--- a/cdk/private/assembly.bzl
+++ b/cdk/private/assembly.bzl
@@ -1,0 +1,32 @@
+"""Rule for running a CDK app with conventional configuration and extracting
+its generated configuration to a defined targeted. Can be consumed by cdk rules
+to diff, deploy, etc.
+
+TODO(dastbe): right now, this rule only works with javascript/typescript apps
+as the others rely on a node runtime for JSII. 
+
+See https://github.com/aws/jsii/issues/3889 for a future fix"""
+
+def _cdk_assembly_impl(ctx):
+    cdk_out = ctx.actions.declare_directory(ctx.attr.name + ".cdk.out")
+
+    ctx.actions.run(
+        outputs = [cdk_out],
+        executable = ctx.executable.app,
+        env = {
+            "CDK_OUTDIR": cdk_out.short_path,
+            # TODO(dastbe): this seems explicitly necessary to make js_binary work?
+            # Would rather not customize this to work with all platforms :shrug:
+            "BAZEL_BINDIR": ctx.var["BINDIR"],
+        },
+        mnemonic = "CdkAssembly",
+    )
+
+    return [DefaultInfo(files = depset([cdk_out]))]
+
+cdk_assembly = rule(
+    implementation = _cdk_assembly_impl,
+    attrs = {
+        "app": attr.label(mandatory = True, executable = True, cfg = "exec"),
+    },
+)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,16 +1,23 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
-Public API re-exports
+Rules for generating CDK assemblies and deploying them
 
-<a id="example"></a>
+<a id="cdk_assembly"></a>
 
-## example
+## cdk_assembly
 
 <pre>
-example()
+cdk_assembly(<a href="#cdk_assembly-name">name</a>, <a href="#cdk_assembly-app">app</a>)
 </pre>
 
-This is an example
 
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="cdk_assembly-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="cdk_assembly-app"></a>app |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 

--- a/e2e/workspace/.bazelignore
+++ b/e2e/workspace/.bazelignore
@@ -1,0 +1,1 @@
+node_modules

--- a/e2e/workspace/BUILD.bazel
+++ b/e2e/workspace/BUILD.bazel
@@ -3,15 +3,15 @@ Add a basic smoke-test target below.
 """
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-# load("contrib_rules_cdk//cdk:defs.bzl", "...")
+load("@npm//:defs.bzl", "npm_link_all_packages")
 
-# Replace with a usage of your rule/macro
-filegroup(name = "empty")
+npm_link_all_packages(
+    name = "node_modules",
+)
 
 build_test(
     name = "smoke_test",
     targets = [
-        # targets you add above
-        ":empty",
+        "//examples/javascript:assembly",
     ],
 )

--- a/e2e/workspace/WORKSPACE
+++ b/e2e/workspace/WORKSPACE
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # Override http_archive for local testing
 local_repository(
     name = "contrib_rules_cdk",
@@ -17,3 +19,34 @@ local_repository(
 load("@contrib_rules_cdk//cdk:repositories.bzl", "rules_cdk_dependencies")
 
 rules_cdk_dependencies()
+
+# Dependencies for javascript e2e tests
+http_archive(
+    name = "aspect_rules_js",
+    sha256 = "66ecc9f56300dd63fb86f11cfa1e8affcaa42d5300e2746dba08541916e913fd",
+    strip_prefix = "rules_js-1.13.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.13.0.tar.gz",
+)
+
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
+load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
+
+nodejs_register_toolchains(
+    name = "nodejs",
+    node_version = DEFAULT_NODE_VERSION,
+)
+
+load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
+
+npm_translate_lock(
+    name = "npm",
+    pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+
+load("@npm//:repositories.bzl", "npm_repositories")
+
+npm_repositories()

--- a/e2e/workspace/examples/javascript/BUILD.bazel
+++ b/e2e/workspace/examples/javascript/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
+load("@contrib_rules_cdk//cdk:defs.bzl", "cdk_assembly")
+
+js_library(
+    name = "lib",
+    srcs = [
+        "app.js",
+        "//:node_modules/aws-cdk-lib",
+    ],
+)
+
+js_binary(
+    name = "bin",
+    data = [
+        ":lib",
+    ],
+    entry_point = "app.js",
+)
+
+cdk_assembly(
+    name = "assembly",
+    app = ":bin",
+    visibility = ["//visibility:public"],
+)

--- a/e2e/workspace/examples/javascript/app.js
+++ b/e2e/workspace/examples/javascript/app.js
@@ -1,0 +1,8 @@
+const cdk = require("aws-cdk-lib");
+const s3 = require("aws-cdk-lib/aws-s3");
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack");
+const bucket = new s3.Bucket(stack, "test-bucket", {});
+
+app.synth();

--- a/e2e/workspace/package.json
+++ b/e2e/workspace/package.json
@@ -1,0 +1,6 @@
+{
+	"dependencies": {
+		"aws-cdk-lib": "^2.56.1",
+		"constructs": "^10.1.198"
+	}
+}

--- a/e2e/workspace/pnpm-lock.yaml
+++ b/e2e/workspace/pnpm-lock.yaml
@@ -1,0 +1,159 @@
+lockfileVersion: 5.4
+
+specifiers:
+  aws-cdk-lib: ^2.56.1
+  constructs: ^10.1.198
+
+dependencies:
+  aws-cdk-lib: 2.56.1_constructs@10.1.198
+  constructs: 10.1.198
+
+packages:
+
+  /@aws-cdk/asset-awscli-v1/2.2.38:
+    resolution: {integrity: sha512-GUnGjY7+krgLrzqnmxOntX8tSMnuvoBKLiuQKFT9tFuGCOKO/rFFvg6dOl83dxH5rANOv5yk1iTkQe3IAGFMSA==}
+    dev: false
+
+  /@aws-cdk/asset-kubectl-v20/2.1.1:
+    resolution: {integrity: sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==}
+    dev: false
+
+  /@aws-cdk/asset-node-proxy-agent-v5/2.0.38:
+    resolution: {integrity: sha512-BBwAjORhuUkTGO3CxGS5Evcp5n20h9v06Sftn2R1DuSm8zIoUlPsNlI1HUk8XqYuoEI4aD7IKRQBLglv09ciJQ==}
+    dev: false
+
+  /@balena/dockerignore/1.0.2:
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+    dev: false
+
+  /at-least-node/1.0.0:
+    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
+    engines: {node: '>= 4.0.0'}
+    dev: false
+
+  /aws-cdk-lib/2.56.1_constructs@10.1.198:
+    resolution: {integrity: sha512-3/dcJmZQHMnQseKRs2r+RstbLJvXwx+A9aJyeBBEF6qJ0BbxGwOYLsWZeLAcvCDf6DcxuYO3lVf88SlQDz8X+w==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      constructs: ^10.0.0
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.38
+      '@aws-cdk/asset-kubectl-v20': 2.1.1
+      '@aws-cdk/asset-node-proxy-agent-v5': 2.0.38
+      '@balena/dockerignore': 1.0.2
+      case: 1.6.3
+      constructs: 10.1.198
+      fs-extra: 9.1.0
+      ignore: 5.2.4
+      jsonschema: 1.4.1
+      minimatch: 3.1.2
+      punycode: 2.1.1
+      semver: 7.3.8
+      yaml: 1.10.2
+    dev: false
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - yaml
+
+  /balanced-match/1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: false
+
+  /brace-expansion/1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: false
+
+  /case/1.6.3:
+    resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
+    engines: {node: '>= 0.8.0'}
+    dev: false
+
+  /concat-map/0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: false
+
+  /constructs/10.1.198:
+    resolution: {integrity: sha512-1WJdJdjoi/GUwvt9hYbPAec4RCq5oylVxmccIZuU2aFPiJjL6xDJbg+2tpZw6kJ+CNwxPGehESL+A7VJ74NGDQ==}
+    engines: {node: '>= 14.17.0'}
+    dev: false
+
+  /fs-extra/9.1.0:
+    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      at-least-node: 1.0.0
+      graceful-fs: 4.2.10
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: false
+
+  /graceful-fs/4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+    dev: false
+
+  /ignore/5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
+    engines: {node: '>= 4'}
+    dev: false
+
+  /jsonfile/6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    dependencies:
+      universalify: 2.0.0
+    optionalDependencies:
+      graceful-fs: 4.2.10
+    dev: false
+
+  /jsonschema/1.4.1:
+    resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
+    dev: false
+
+  /lru-cache/6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+    dependencies:
+      yallist: 4.0.0
+    dev: false
+
+  /minimatch/3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: false
+
+  /punycode/2.1.1:
+    resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /semver/7.3.8:
+    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
+
+  /universalify/2.0.0:
+    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
+    engines: {node: '>= 10.0.0'}
+    dev: false
+
+  /yallist/4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: false
+
+  /yaml/1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+    dev: false


### PR DESCRIPTION
This change defines `cdk_assembly` which adds the following
functionality.

* Run a CDK app with the correct environment
* Track the resulting cloud assembly to be consumed by other rules

Additionally, adds an e2e test for javascript. At the moment, only
javascript and typescript apps will work as we don't yet configure the
underlying node/jsii runtime.
