### PR TITLE
feat: add basic versions of cdk_destroy and cdk_bootstrap

### DIFF
--- a/cdk/BUILD.bazel
+++ b/cdk/BUILD.bazel
@@ -31,7 +31,9 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cdk/private:cdk_assembly",
+        "//cdk/private:cdk_bootstrap",
         "//cdk/private:cdk_deploy",
+        "//cdk/private:cdk_destroy",
         "//cdk/private:cdk_diff",
     ],
 )

--- a/cdk/defs.bzl
+++ b/cdk/defs.bzl
@@ -1,9 +1,13 @@
 """Rules for generating CDK assemblies and deploying them"""
 
 load("//cdk/private:assembly.bzl", _cdk_assembly = "cdk_assembly")
+load("//cdk/private:bootstrap.bzl", _cdk_bootstrap = "cdk_bootstrap")
 load("//cdk/private:deploy.bzl", _cdk_deploy = "cdk_deploy")
+load("//cdk/private:destroy.bzl", _cdk_destroy = "cdk_destroy")
 load("//cdk/private:diff.bzl", _cdk_diff = "cdk_diff")
 
 cdk_assembly = _cdk_assembly
+cdk_bootstrap = _cdk_bootstrap
 cdk_deploy = _cdk_deploy
+cdk_destroy = _cdk_destroy
 cdk_diff = _cdk_diff

--- a/cdk/private/BUILD.bazel
+++ b/cdk/private/BUILD.bazel
@@ -13,8 +13,14 @@ bzl_library(
 )
 
 bzl_library(
-    name = "cdk_diff",
-    srcs = ["diff.bzl"],
+    name = "cdk_bootstrap",
+    srcs = ["bootstrap.bzl"],
+    visibility = ["//cdk:__subpackages__"],
+)
+
+bzl_library(
+    name = "cdk_deploy",
+    srcs = ["deploy.bzl"],
     visibility = ["//cdk:__subpackages__"],
     deps = [
         "@aspect_rules_js//js:defs",
@@ -22,8 +28,17 @@ bzl_library(
 )
 
 bzl_library(
-    name = "cdk_deploy",
-    srcs = ["deploy.bzl"],
+    name = "cdk_destroy",
+    srcs = ["destroy.bzl"],
+    visibility = ["//cdk:__subpackages__"],
+    deps = [
+        "@aspect_rules_js//js:defs",
+    ],
+)
+
+bzl_library(
+    name = "cdk_diff",
+    srcs = ["diff.bzl"],
     visibility = ["//cdk:__subpackages__"],
     deps = [
         "@aspect_rules_js//js:defs",

--- a/cdk/private/bootstrap.bzl
+++ b/cdk/private/bootstrap.bzl
@@ -1,0 +1,15 @@
+"""TODO"""
+
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
+
+def cdk_bootstrap(name):
+    js_binary(
+        name = name,
+        data = [
+            "@cdk//:cdk",
+        ],
+        entry_point = "@cdk//:cdk_entry_point",
+        args = [
+            "bootstrap",
+        ],
+    )

--- a/cdk/private/destroy.bzl
+++ b/cdk/private/destroy.bzl
@@ -1,0 +1,18 @@
+"""TODO"""
+
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
+
+def cdk_destroy(name, assembly):
+    js_binary(
+        name = name,
+        data = [
+            assembly,
+            "@cdk//:cdk",
+        ],
+        entry_point = "@cdk//:cdk_entry_point",
+        args = [
+            "destroy",
+            "--app",
+            "$(location {assembly})".format(assembly = assembly),
+        ],
+    )

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -21,6 +21,24 @@ cdk_assembly(<a href="#cdk_assembly-name">name</a>, <a href="#cdk_assembly-app">
 | <a id="cdk_assembly-app"></a>app |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 
+<a id="cdk_bootstrap"></a>
+
+## cdk_bootstrap
+
+<pre>
+cdk_bootstrap(<a href="#cdk_bootstrap-name">name</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="cdk_bootstrap-name"></a>name |  <p align="center"> - </p>   |  none |
+
+
 <a id="cdk_deploy"></a>
 
 ## cdk_deploy
@@ -38,6 +56,25 @@ cdk_deploy(<a href="#cdk_deploy-name">name</a>, <a href="#cdk_deploy-assembly">a
 | :------------- | :------------- | :------------- |
 | <a id="cdk_deploy-name"></a>name |  <p align="center"> - </p>   |  none |
 | <a id="cdk_deploy-assembly"></a>assembly |  <p align="center"> - </p>   |  none |
+
+
+<a id="cdk_destroy"></a>
+
+## cdk_destroy
+
+<pre>
+cdk_destroy(<a href="#cdk_destroy-name">name</a>, <a href="#cdk_destroy-assembly">assembly</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="cdk_destroy-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="cdk_destroy-assembly"></a>assembly |  <p align="center"> - </p>   |  none |
 
 
 <a id="cdk_diff"></a>

--- a/e2e/workspace/BUILD.bazel
+++ b/e2e/workspace/BUILD.bazel
@@ -4,6 +4,7 @@ Add a basic smoke-test target below.
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@contrib_rules_cdk//cdk:defs.bzl", "cdk_bootstrap")
 
 npm_link_all_packages(
     name = "node_modules",
@@ -15,3 +16,5 @@ build_test(
         "//examples/javascript:assembly",
     ],
 )
+
+cdk_bootstrap(name = "bootstrap")

--- a/e2e/workspace/examples/javascript/BUILD.bazel
+++ b/e2e/workspace/examples/javascript/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
-load("@contrib_rules_cdk//cdk:defs.bzl", "cdk_assembly", "cdk_deploy", "cdk_diff")
+load("@contrib_rules_cdk//cdk:defs.bzl", "cdk_assembly", "cdk_deploy", "cdk_destroy", "cdk_diff")
 
 js_library(
     name = "lib",
@@ -30,5 +30,10 @@ cdk_diff(
 
 cdk_deploy(
     name = "deploy",
+    assembly = ":assembly",
+)
+
+cdk_destroy(
+    name = "destroy",
     assembly = ":assembly",
 )


### PR DESCRIPTION
This adds initial implementations of `cdk_destroy` and `cdk_bootstrap`.
`cdk_bootstrap` is really a convenience function for testing, whereas
`cdk_bootstrap` is for now just for bootstrapping a cdk environment in
your personal account, but in the future could be used for automating
account bootstrap with writeback.
