### PR TITLE
chore: exclude versioned cdk deps from renovation

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:base"],
+  "ignorePaths": ["**/cdk/v*"]
 }


### PR DESCRIPTION
These are purposefully fixed at certain versions.
