### PR TITLE
chore: fix bazel cache caching in actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
+      - name: Configure Bazel version
+        working-directory: ${{ matrix.folder }}
+        run: echo "${{ matrix.bazelversion }}" > .bazelversion
+
       # Cache build and external artifacts so that the next ci build is incremental.
       # Because github action caches cannot be updated after a build, we need to
       # store the contents of each build in a unique cache key, then fall back to loading
@@ -72,14 +76,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            "~/.cache/bazel"
-            "~/.cache/bazel-repo"
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
+            ~/.cache/bazel
+            ~/.cache/bazel-repo
+          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', '.bazelversion') }}
           restore-keys: bazel-cache-
-
-      - name: Configure Bazel version
-        working-directory: ${{ matrix.folder }}
-        run: echo "${{ matrix.bazelversion }}" > .bazelversion
 
       - name: Check for test.sh
         # Checks for the existence of test.sh in the folder. Downstream steps can use
@@ -138,9 +138,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            "~/.cache/bazel"
-            "~/.cache/bazel-repo"
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
+            ~/.cache/bazel
+            ~/.cache/bazel-repo
+          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', '.bazelversion') }}
           restore-keys: bazel-cache-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            "~/.cache/bazel"
-            "~/.cache/bazel-repo"
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
+            ~/.cache/bazel
+            ~/.cache/bazel-repo
+          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', '.bazelversion') }}
           restore-keys: bazel-cache-
       - name: bazel test //...
         env:


### PR DESCRIPTION
* the vertical bar operator doesn't unquote strings, i.e. it operators
  on its input literally. Since the quoted versions of the paths aren't
  in the filesystem, Github Actions barfs.
* Move the .bazelversion setup ahead of cache and integrate it into the
  caching files itself. It's not clear to me that the cache should be
  valid across versions so better to err on the conservative side.
