### PR TITLE
feat: copy assembly out to temporary directory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,6 +107,13 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - "//examples/javascript"
+          - "//examples/static"
+
     # only have one of these jobs running at any given time
     concurrency: deploy-examples
 
@@ -153,12 +160,18 @@ jobs:
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         working-directory: "e2e/workspace"
         run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc build //...
-      - name: bazel run //examples/javascript:deploy
+      - name: bazel run :diff
         env:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         working-directory: "e2e/workspace"
-        run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc run //examples/javascript:deploy
+        run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc run ${{ matrix.target }}:diff
+      - name: bazel run :deploy
+        env:
+          # Bazelisk will download bazel to here, ensure it is cached between runs.
+          XDG_CACHE_HOME: ~/.cache/bazel-repo
+        working-directory: "e2e/workspace"
+        run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc run ${{ matrix.target }}:deploy
 
       - name: ./test.sh
         # Run if there is a test.sh file in the folder

--- a/cdk/dependencies.bzl
+++ b/cdk/dependencies.bzl
@@ -38,6 +38,7 @@ Please instead choose one of these available versions: {}""".format(cdk_version,
         additional_file_contents = {
             "BUILD.bazel": [
                 """load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")""",
+                """load("@aspect_rules_js//js:defs.bzl", "js_binary")""",
                 """load("//:npm_link_all_packages.bzl", "npm_link_all_packages")""",
                 """npm_link_all_packages(name = "node_modules")""",
                 """directory_path(
@@ -49,6 +50,14 @@ Please instead choose one of these available versions: {}""".format(cdk_version,
                 """alias(
     name = "cdk",
     actual = ":node_modules/aws-cdk",
+    visibility = ["//visibility:public"],
+)""",
+                """js_binary(
+    name = "cdk_bin",
+    data = [
+        ":cdk",
+    ],
+    entry_point = ":cdk_entry_point",
     visibility = ["//visibility:public"],
 )""",
             ],

--- a/cdk/private/BUILD.bazel
+++ b/cdk/private/BUILD.bazel
@@ -1,6 +1,15 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
+    name = "cdk_exec",
+    srcs = ["exec.bzl"],
+    visibility = ["//cdk/private:__subpackages__"],
+    deps = [
+        "@aspect_rules_js//js:defs",
+    ],
+)
+
+bzl_library(
     name = "versions",
     srcs = ["versions.bzl"],
     visibility = ["//cdk:__subpackages__"],
@@ -23,6 +32,7 @@ bzl_library(
     srcs = ["deploy.bzl"],
     visibility = ["//cdk:__subpackages__"],
     deps = [
+        ":cdk_exec",
         "@aspect_rules_js//js:defs",
     ],
 )
@@ -32,6 +42,7 @@ bzl_library(
     srcs = ["destroy.bzl"],
     visibility = ["//cdk:__subpackages__"],
     deps = [
+        ":cdk_exec",
         "@aspect_rules_js//js:defs",
     ],
 )
@@ -41,6 +52,7 @@ bzl_library(
     srcs = ["diff.bzl"],
     visibility = ["//cdk:__subpackages__"],
     deps = [
+        ":cdk_exec",
         "@aspect_rules_js//js:defs",
     ],
 )

--- a/cdk/private/deploy.bzl
+++ b/cdk/private/deploy.bzl
@@ -1,18 +1,10 @@
 """TODO"""
 
-load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load(":exec.bzl", "cdk_exec")
 
 def cdk_deploy(name, assembly):
-    js_binary(
+    cdk_exec(
         name = name,
-        data = [
-            assembly,
-            "@cdk//:cdk",
-        ],
-        entry_point = "@cdk//:cdk_entry_point",
-        args = [
-            "deploy",
-            "--app",
-            "$(location {assembly})".format(assembly = assembly),
-        ],
+        assembly = assembly,
+        action = "deploy",
     )

--- a/cdk/private/destroy.bzl
+++ b/cdk/private/destroy.bzl
@@ -1,18 +1,10 @@
 """TODO"""
 
-load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load(":exec.bzl", "cdk_exec")
 
 def cdk_destroy(name, assembly):
-    js_binary(
+    cdk_exec(
         name = name,
-        data = [
-            assembly,
-            "@cdk//:cdk",
-        ],
-        entry_point = "@cdk//:cdk_entry_point",
-        args = [
-            "destroy",
-            "--app",
-            "$(location {assembly})".format(assembly = assembly),
-        ],
+        assembly = assembly,
+        action = "destroy",
     )

--- a/cdk/private/diff.bzl
+++ b/cdk/private/diff.bzl
@@ -1,18 +1,10 @@
 """TODO"""
 
-load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load(":exec.bzl", "cdk_exec")
 
 def cdk_diff(name, assembly):
-    js_binary(
+    cdk_exec(
         name = name,
-        data = [
-            assembly,
-            "@cdk//:cdk",
-        ],
-        entry_point = "@cdk//:cdk_entry_point",
-        args = [
-            "diff",
-            "--app",
-            "$(location {assembly})".format(assembly = assembly),
-        ],
+        assembly = assembly,
+        action = "diff",
     )

--- a/cdk/private/exec.bzl
+++ b/cdk/private/exec.bzl
@@ -1,0 +1,47 @@
+"""TODO"""
+
+CDK_ACTIONS = [
+    "deploy",
+    "diff",
+    "destroy",
+]
+
+deploy_template = """\
+#!/bin/bash
+CLOUD_ASSEMBLY=$(rootpath {assembly})
+WRITEABLE_CLOUD_ASSEMBLY=$(mktemp -d)
+
+# Forward slash is load-bearing
+cp -r $CLOUD_ASSEMBLY/. $WRITEABLE_CLOUD_ASSEMBLY
+chmod -R 755 $WRITEABLE_CLOUD_ASSEMBLY
+
+$(rootpath {cdk}) {action} --app $WRITEABLE_CLOUD_ASSEMBLY
+"""
+
+def _cdk_exec_impl(ctx):
+    script = ctx.actions.declare_file("%s.sh" % ctx.label.name)
+    script_content = ctx.expand_location(deploy_template.format(action = ctx.attr.action, 
+         assembly = ctx.attr.assembly.label, 
+         cdk = ctx.attr.cdk.label), 
+      targets = [ctx.attr.assembly, ctx.attr.cdk])
+
+    ctx.actions.write(script, script_content, is_executable = True)
+
+    files = []
+    files.extend(ctx.files.assembly)
+    files.extend(ctx.files.cdk)
+    runfiles = ctx.runfiles(files = files)
+    runfiles = runfiles.merge(ctx.attr.assembly[DefaultInfo].default_runfiles)
+    runfiles = runfiles.merge(ctx.attr.cdk[DefaultInfo].default_runfiles)
+
+    return [DefaultInfo(executable = script, runfiles = runfiles)]
+
+cdk_exec = rule(
+    implementation = _cdk_exec_impl,
+    executable = True,
+    attrs = {
+        "assembly": attr.label(mandatory = True, allow_single_file = True),
+        "cdk": attr.label(default = "@cdk//:cdk_bin", allow_single_file = True, executable = True, cfg = "exec"),
+        "action": attr.string(mandatory = True, values = CDK_ACTIONS),
+    },
+)

--- a/e2e/workspace/WORKSPACE
+++ b/e2e/workspace/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "e2e")
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Override http_archive for local testing

--- a/e2e/workspace/examples/static/BUILD.bazel
+++ b/e2e/workspace/examples/static/BUILD.bazel
@@ -1,0 +1,47 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
+load("@contrib_rules_cdk//cdk:defs.bzl", "cdk_assembly", "cdk_deploy", "cdk_destroy", "cdk_diff")
+
+filegroup(
+    name = "content",
+    srcs = [
+        "content/static.txt",
+    ],
+)
+
+js_library(
+    name = "lib",
+    srcs = [
+        "app.js",
+        "//:node_modules/aws-cdk-lib",
+    ],
+)
+
+js_binary(
+    name = "bin",
+    data = [
+        ":content",
+        ":lib",
+    ],
+    entry_point = "app.js",
+)
+
+cdk_assembly(
+    name = "assembly",
+    app = ":bin",
+    visibility = ["//visibility:public"],
+)
+
+cdk_diff(
+    name = "diff",
+    assembly = ":assembly",
+)
+
+cdk_deploy(
+    name = "deploy",
+    assembly = ":assembly",
+)
+
+cdk_destroy(
+    name = "destroy",
+    assembly = ":assembly",
+)

--- a/e2e/workspace/examples/static/app.js
+++ b/e2e/workspace/examples/static/app.js
@@ -1,0 +1,14 @@
+const cdk = require("aws-cdk-lib");
+const s3 = require("aws-cdk-lib/aws-s3");
+const s3deploy = require("aws-cdk-lib/aws-s3-deployment");
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "StaticContentStack");
+
+const bucket = new s3.Bucket(stack, 'Bucket', {});
+new s3deploy.BucketDeployment(stack, 'Content', {
+  sources: [s3deploy.Source.asset(`${process.env.RUNFILES}/e2e/examples/static/content`)],
+  destinationBucket: bucket,
+});
+
+app.synth();

--- a/e2e/workspace/examples/static/content/static.txt
+++ b/e2e/workspace/examples/static/content/static.txt
@@ -1,0 +1,1 @@
+Hello, World!


### PR DESCRIPTION
Unfortunately, some CDK applications perform modifications within the
cloud assembly itself. Because bazel makes the directories it provides
as inputs read-only, this means that any application that trips over
this will just fail.

To fix this, we copy the assembly to a temporary directory prior to
invoking the CDK.

Fixes: #31
