### PR TITLE
chore: stop running github actions on push to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,7 @@ name: CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches: [main]
+  # Triggers the workflow on pull request events but only for the main branch
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Since we're already validating the main branch as part of the main
queue, these are just superfluous runs.
