### PR TITLE
feat: support arbitrary CDK languages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,7 @@ jobs:
       matrix:
         target:
           - "//examples/javascript"
+          - "//examples/golang"
           - "//examples/static"
 
     # only have one of these jobs running at any given time

--- a/cdk/private/assembly.bzl
+++ b/cdk/private/assembly.bzl
@@ -1,24 +1,38 @@
 """Rule for running a CDK app with conventional configuration and extracting
 its generated configuration to a defined targeted. Can be consumed by cdk rules
-to diff, deploy, etc.
+to diff, deploy, etc."""
 
-TODO(dastbe): right now, this rule only works with javascript/typescript apps
-as the others rely on a node runtime for JSII. 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 
-See https://github.com/aws/jsii/issues/3889 for a future fix"""
+# this is a pretty big hack to use pwd to resolve the full path of the node binary
+# This is necessary because go no longer allows relative-path lookups. Ideally we
+# can get rid of this if we can support an alternative way of specifying the
+# node entrypoint: https://github.com/aws/jsii/issues/3889
+#
+# separately, all js_binaries need to have BAZEL_BINDIR. Hopefully this doesn't
+# pollute further :/
+command_template = """\
+PATH=`pwd`/{node}:$PATH CDK_OUTDIR=`pwd`/{cdk_outdir} BAZEL_BINDIR={bindir} $(execpath {app})
+"""
 
 def _cdk_assembly_impl(ctx):
     cdk_out = ctx.actions.declare_directory(ctx.attr.name + ".cdk.out")
+    node_toolchain = ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"].nodeinfo
 
-    ctx.actions.run(
+    files = []
+    files.extend(ctx.files.app)
+    files.extend(node_toolchain.npm_files)
+    files.extend(node_toolchain.tool_files)
+    runfiles = ctx.runfiles(files = files)
+    runfiles = runfiles.merge(ctx.attr.app[DefaultInfo].default_runfiles)
+
+    command = ctx.expand_location(command_template.format(node = paths.dirname(node_toolchain.target_tool_path), cdk_outdir = cdk_out.path, bindir = ctx.var["BINDIR"], app = ctx.attr.app.label), targets = [ctx.attr.app])
+
+    ctx.actions.run_shell(
+        inputs = runfiles.files.to_list(),
         outputs = [cdk_out],
-        executable = ctx.executable.app,
-        env = {
-            "CDK_OUTDIR": cdk_out.short_path,
-            # TODO(dastbe): this seems explicitly necessary to make js_binary work?
-            # Would rather not customize this to work with all platforms :shrug:
-            "BAZEL_BINDIR": ctx.var["BINDIR"],
-        },
+        tools = ctx.files.app,
+        command = command,
         mnemonic = "CdkAssembly",
     )
 
@@ -29,4 +43,5 @@ cdk_assembly = rule(
     attrs = {
         "app": attr.label(mandatory = True, doc = "The CDK application used to generate the cloud assembly", executable = True, cfg = "exec"),
     },
+    toolchains = ["@rules_nodejs//nodejs:toolchain_type"],
 )

--- a/devbox.json
+++ b/devbox.json
@@ -1,11 +1,11 @@
 {
   "packages": [
     "nodePackages.pnpm",
-    "nodejs",
     "pre-commit",
     "awscli2",
     "git-branchless",
-    "bazelisk"
+    "bazelisk",
+    "go"
   ],
   "shell": {
     "init_hook": null

--- a/e2e/workspace/BUILD.bazel
+++ b/e2e/workspace/BUILD.bazel
@@ -5,6 +5,7 @@ Add a basic smoke-test target below.
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@contrib_rules_cdk//cdk:defs.bzl", "cdk_bootstrap")
+load("@bazel_gazelle//:def.bzl", "gazelle")
 
 npm_link_all_packages(
     name = "node_modules",
@@ -14,7 +15,28 @@ build_test(
     name = "smoke_test",
     targets = [
         "//examples/javascript:assembly",
+        "//examples/golang:assembly",
     ],
+)
+
+# gazelle:prefix github.com/dastbe/rules_cdk/e2e/workplace
+gazelle(
+    name = "gazelle",
+    args = [
+        "-go_naming_convention=go_default_library",
+    ],
+    command = "update",
+)
+
+gazelle(
+    name = "gazelle-update-repos",
+    args = [
+        "-build_external=external",
+        "-from_file=go.mod",
+        "-to_macro=deps.bzl%go_dependencies",
+        "-prune",
+    ],
+    command = "update-repos",
 )
 
 cdk_bootstrap(name = "bootstrap")

--- a/e2e/workspace/WORKSPACE
+++ b/e2e/workspace/WORKSPACE
@@ -15,6 +15,24 @@ http_archive(
     url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.13.0.tar.gz",
 )
 
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "56d8c5a5c91e1af73eca71a6fab2ced959b67c86d12ba37feedb0a2dfea441a6",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.37.0/rules_go-v0.37.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.37.0/rules_go-v0.37.0.zip",
+    ],
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "448e37e0dbf61d6fa8f00aaa12d191745e14f07c31cabfa731f0c8e8a4f41b97",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz",
+    ],
+)
+
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 
 rules_js_dependencies()
@@ -30,6 +48,21 @@ npm_translate_lock(
 load("@npm//:repositories.bzl", "npm_repositories")
 
 npm_repositories()
+
+# rules_go
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.19.3")
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("//:deps.bzl", "go_dependencies")
+
+# gazelle:repository_macro deps.bzl%go_dependencies
+go_dependencies()
+
+gazelle_dependencies()
 
 #---SNIP--- Below here is re-used in the workspace snippet published on releases
 

--- a/e2e/workspace/deps.bzl
+++ b/e2e/workspace/deps.bzl
@@ -1,0 +1,125 @@
+"""WORKSPACE level dependencies"""
+
+load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+def go_dependencies():
+    """Initialize all go_repository targets for this WORKSPACE"""
+    go_repository(
+        name = "com_github_aws_aws_cdk_go_awscdk_v2",
+        build_external = "external",
+        importpath = "github.com/aws/aws-cdk-go/awscdk/v2",
+        sum = "h1:3gi34Y7Z8zmvcxUYnRcQrh2doW/RsXAsy+V1JD1ej7I=",
+        version = "v2.58.1",
+    )
+    go_repository(
+        name = "com_github_aws_constructs_go_constructs_v10",
+        build_external = "external",
+        importpath = "github.com/aws/constructs-go/constructs/v10",
+        sum = "h1:PmI42w6gXXcXBMZgx6KO0ndHb5xGyUcndV39/nPzxMU=",
+        version = "v10.1.189",
+    )
+    go_repository(
+        name = "com_github_aws_jsii_runtime_go",
+        build_external = "external",
+        importpath = "github.com/aws/jsii-runtime-go",
+        sum = "h1:5jMBCUu/qINj0hSt08gkyVyKRbrRBb9RV8ETGxTb+lo=",
+        version = "v1.72.0",
+    )
+    go_repository(
+        name = "com_github_cdklabs_awscdk_asset_awscli_go_awscliv1_v2",
+        build_external = "external",
+        importpath = "github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2",
+        sum = "h1:ryT4dP31QvXF7SO3mij6ir+8JBRaHyv1NSd2seUgpH4=",
+        version = "v2.2.30",
+    )
+    go_repository(
+        name = "com_github_cdklabs_awscdk_asset_kubectl_go_kubectlv20_v2",
+        build_external = "external",
+        importpath = "github.com/cdklabs/awscdk-asset-kubectl-go/kubectlv20/v2",
+        sum = "h1:l5N27aCCjAB5cgW5pI4/ujnasPL8hUcJ9KBxrKk6UiQ=",
+        version = "v2.1.1",
+    )
+    go_repository(
+        name = "com_github_cdklabs_awscdk_asset_node_proxy_agent_go_nodeproxyagentv5_v2",
+        build_external = "external",
+        importpath = "github.com/cdklabs/awscdk-asset-node-proxy-agent-go/nodeproxyagentv5/v2",
+        sum = "h1:IgRq7F3odfHx5cnb+ejlMV+jGTmNOH7pJnSt8ownfvc=",
+        version = "v2.0.38",
+    )
+    go_repository(
+        name = "com_github_davecgh_go_spew",
+        build_external = "external",
+        importpath = "github.com/davecgh/go-spew",
+        sum = "h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=",
+        version = "v1.1.1",
+    )
+    go_repository(
+        name = "com_github_masterminds_semver_v3",
+        build_external = "external",
+        importpath = "github.com/Masterminds/semver/v3",
+        sum = "h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=",
+        version = "v3.2.0",
+    )
+    go_repository(
+        name = "com_github_mattn_go_isatty",
+        build_external = "external",
+        importpath = "github.com/mattn/go-isatty",
+        sum = "h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=",
+        version = "v0.0.16",
+    )
+    go_repository(
+        name = "com_github_pmezard_go_difflib",
+        build_external = "external",
+        importpath = "github.com/pmezard/go-difflib",
+        sum = "h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=",
+        version = "v1.0.0",
+    )
+    go_repository(
+        name = "com_github_stretchr_testify",
+        build_external = "external",
+        importpath = "github.com/stretchr/testify",
+        sum = "h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=",
+        version = "v1.8.1",
+    )
+    go_repository(
+        name = "com_github_yuin_goldmark",
+        build_external = "external",
+        importpath = "github.com/yuin/goldmark",
+        sum = "h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=",
+        version = "v1.4.13",
+    )
+    go_repository(
+        name = "in_gopkg_yaml_v3",
+        build_external = "external",
+        importpath = "gopkg.in/yaml.v3",
+        sum = "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=",
+        version = "v3.0.1",
+    )
+    go_repository(
+        name = "org_golang_x_lint",
+        build_external = "external",
+        importpath = "golang.org/x/lint",
+        sum = "h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=",
+        version = "v0.0.0-20210508222113-6edffad5e616",
+    )
+    go_repository(
+        name = "org_golang_x_mod",
+        build_external = "external",
+        importpath = "golang.org/x/mod",
+        sum = "h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=",
+        version = "v0.7.0",
+    )
+    go_repository(
+        name = "org_golang_x_sys",
+        build_external = "external",
+        importpath = "golang.org/x/sys",
+        sum = "h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=",
+        version = "v0.2.0",
+    )
+    go_repository(
+        name = "org_golang_x_tools",
+        build_external = "external",
+        importpath = "golang.org/x/tools",
+        sum = "h1:SrNbZl6ECOS1qFzgTdQfWXZM9XBkiA6tkFrH9YSTPHM=",
+        version = "v0.3.0",
+    )

--- a/e2e/workspace/examples/golang/BUILD.bazel
+++ b/e2e/workspace/examples/golang/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@contrib_rules_cdk//cdk:defs.bzl", "cdk_assembly", "cdk_deploy", "cdk_destroy", "cdk_diff")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/dastbe/rules_cdk/e2e/workplace/examples/golang",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_aws_aws_cdk_go_awscdk_v2//:go_default_library",
+        "@com_github_aws_aws_cdk_go_awscdk_v2//awsappmesh:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "app",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+cdk_assembly(
+    name = "assembly",
+    app = ":app",
+    visibility = ["//visibility:public"],
+)
+
+cdk_diff(
+    name = "diff",
+    assembly = ":assembly",
+)
+
+cdk_deploy(
+    name = "deploy",
+    assembly = ":assembly",
+)
+
+cdk_destroy(
+    name = "destroy",
+    assembly = ":assembly",
+)

--- a/e2e/workspace/examples/golang/main.go
+++ b/e2e/workspace/examples/golang/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/aws/aws-cdk-go/awscdk/v2"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awsappmesh"
+)
+
+func main() {
+	stackName := "GolangStack"
+	meshName := "golang-mesh"
+
+	app := awscdk.NewApp(nil)
+	stack := awscdk.NewStack(app, &stackName, &awscdk.StackProps{})
+	awsappmesh.NewMesh(stack, &meshName, &awsappmesh.MeshProps{})
+
+	app.Synth(nil)
+}

--- a/e2e/workspace/examples/javascript/BUILD.bazel
+++ b/e2e/workspace/examples/javascript/BUILD.bazel
@@ -10,7 +10,7 @@ js_library(
 )
 
 js_binary(
-    name = "bin",
+    name = "app",
     data = [
         ":lib",
     ],
@@ -19,7 +19,7 @@ js_binary(
 
 cdk_assembly(
     name = "assembly",
-    app = ":bin",
+    app = ":app",
     visibility = ["//visibility:public"],
 )
 

--- a/e2e/workspace/go.mod
+++ b/e2e/workspace/go.mod
@@ -1,0 +1,14 @@
+module github.com/dastbe/rules_cdk/e2e/workspace
+
+go 1.19
+
+require github.com/aws/aws-cdk-go/awscdk/v2 v2.58.1
+
+require (
+	github.com/Masterminds/semver/v3 v3.2.0 // indirect
+	github.com/aws/constructs-go/constructs/v10 v10.1.189 // indirect
+	github.com/aws/jsii-runtime-go v1.72.0 // indirect
+	github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.30 // indirect
+	github.com/cdklabs/awscdk-asset-kubectl-go/kubectlv20/v2 v2.1.1 // indirect
+	github.com/cdklabs/awscdk-asset-node-proxy-agent-go/nodeproxyagentv5/v2 v2.0.38 // indirect
+)

--- a/e2e/workspace/go.sum
+++ b/e2e/workspace/go.sum
@@ -1,0 +1,14 @@
+github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
+github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/aws/aws-cdk-go/awscdk/v2 v2.58.1 h1:3gi34Y7Z8zmvcxUYnRcQrh2doW/RsXAsy+V1JD1ej7I=
+github.com/aws/aws-cdk-go/awscdk/v2 v2.58.1/go.mod h1:C6aU5w7MABoOb+uFDW4DoQuL4bwkE56+AW4G6BYHO4k=
+github.com/aws/constructs-go/constructs/v10 v10.1.189 h1:PmI42w6gXXcXBMZgx6KO0ndHb5xGyUcndV39/nPzxMU=
+github.com/aws/constructs-go/constructs/v10 v10.1.189/go.mod h1:Jx57tX1dGJwvmOiqKPIZEUDPY9xKRCd1zag5cg1u5aw=
+github.com/aws/jsii-runtime-go v1.72.0 h1:5jMBCUu/qINj0hSt08gkyVyKRbrRBb9RV8ETGxTb+lo=
+github.com/aws/jsii-runtime-go v1.72.0/go.mod h1:lExVNqTnEcbS/NMnuovDrHohgmPK3IsGdqvaYLA+N1s=
+github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.30 h1:ryT4dP31QvXF7SO3mij6ir+8JBRaHyv1NSd2seUgpH4=
+github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.30/go.mod h1:tlNrUd0+vEvsVTA0C1lE0p2txRPrnK53kb44hCuxdDI=
+github.com/cdklabs/awscdk-asset-kubectl-go/kubectlv20/v2 v2.1.1 h1:l5N27aCCjAB5cgW5pI4/ujnasPL8hUcJ9KBxrKk6UiQ=
+github.com/cdklabs/awscdk-asset-kubectl-go/kubectlv20/v2 v2.1.1/go.mod h1:CvFHBo0qcg8LUkJqIxQtP1rD/sNGv9bX3L2vHT2FUAo=
+github.com/cdklabs/awscdk-asset-node-proxy-agent-go/nodeproxyagentv5/v2 v2.0.38 h1:IgRq7F3odfHx5cnb+ejlMV+jGTmNOH7pJnSt8ownfvc=
+github.com/cdklabs/awscdk-asset-node-proxy-agent-go/nodeproxyagentv5/v2 v2.0.38/go.mod h1:nh+vhRCLVkw4XOCpller0iKwUxQSs7PbRZnaQ4WoqSw=


### PR DESCRIPTION
While https://github.com/aws/jsii/issues/3889 would be the best possible
outcome for supporting arbitrary languages, this hacks around the
current implementation looking up the node bin from the path, as well as
hacking around go's refusal to look up binaries that are in a relative
directory.
